### PR TITLE
Convert test to MJS and upgrade node-fetch

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,6 +22,7 @@ Dockerfile      text eol=lf
 *.scss          text eol=lf
 *.js            text eol=lf
 *.jsx           text eol=lf
+*.mjs           text eol=lf
 *.ts            text eol=lf
 *.tsx           text eol=lf
 *.map           text eol=lf

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "devDependencies": {
     "mocha": "9.1.2",
-    "node-fetch": "2.6.1"
+    "node-fetch": "3.0.0"
   },
   "scripts": {
     "test": "mocha test/mocha/*.test.js --timeout 5000"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
     "node-fetch": "3.0.0"
   },
   "scripts": {
-    "test": "mocha test/mocha/*.test.js --timeout 5000"
+    "test": "mocha test/mocha/*.test.mjs --timeout 5000"
   }
 }

--- a/test/mocha/index.test.mjs
+++ b/test/mocha/index.test.mjs
@@ -1,8 +1,6 @@
 /* eslint-env node, mocha */
-/* eslint-disable prefer-arrow-callback */
-"use strict";
-const {strictEqual} = require("assert");
-const fetch = require("node-fetch");
+import {strictEqual} from "assert";
+import fetch from "node-fetch";
 
 it("Server responds", async function () {
 	const res = await fetch("http://src.local:3000/");


### PR DESCRIPTION
`node-fetch` 3.0.0 is ESM only, so I converted the small test to MJS for now.

Usually I only do CJS/JS or ESM/TS because of my Eslint configs (given MJS would need to use the Babel parser) but the Docker images don't have enough JS/TS code to need Eslint, so MJS is a good enough compromise (also, TS 4.5 is meant to finally handle Export Maps, so TS Eslint might be able to handle MJS soon if needed).